### PR TITLE
stringify nodes if fallback.lenght > 1

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -9,6 +9,8 @@ const customPropertiesRegExp = /(^|[^\w-])var\([\W\w]+\)/;
 // whether the declaration should be potentially transformed
 const isTransformableDecl = (decl) => customPropertiesRegExp.test(decl.value);
 
+const { nodeToString } = require('postcss-values-parser');
+
 // eslint-disable-next-line no-empty-pattern
 module.exports = (opts) => ({
   postcssPlugin: 'postcss-custom-properties-fallback',
@@ -31,10 +33,33 @@ module.exports = (opts) => ({
               return;
             }
             const fallback = customProperties[node.nodes[0].value];
-            if (fallback) {
+
+            if (fallback && fallback.length === 1) {
               node.nodes.push(
-                { type: 'divider', value: ',' },
-                { type: 'word', value: fallback }
+                {
+                  type: 'divider',
+                  value: ',',
+                },
+                {
+                  type: 'word',
+                  value: fallback,
+                }
+              );
+            }
+
+            //when fallback value contains more then one node, stringify them with value parser used to parse the customProperties object and add as one node type word.
+            if (fallback && fallback.length > 1) {
+              node.nodes.push(
+                {
+                  type: 'divider',
+                  value: ',',
+                },
+                {
+                  type: 'word',
+                  value: fallback
+                    .map((fallbackNode) => nodeToString(fallbackNode))
+                    .join(' '),
+                }
               );
             }
           });


### PR DESCRIPTION
This PR fixes issue #45 by checking if `fallback` contains more than one node. If so, it takes all nodes, stringifies them back with the [correct parser](https://github.com/shellscape/postcss-values-parser/tree/5aea4d7e1b5cc8ebb9401379ef06c17213585493). Then this string is used as a value of the node pushed to the array of nodes of the value of the declaration that needs the fallback value. 

This bug that this PR fixes is caused by the use of two different postcss value parsers that differ with one letter in the package name! The[ less complex one](https://www.npmjs.com/package/postcss-value-parser) sometimes understands the interface of the nodes from the more advanced other, because they share the same properties keys, but that happens only when it is only one value node without any children. In the case of box-shadow, we have up to 4 nodes and the less complex parser is unable to put them back together. 

I am not sure if the solution proposed in this PR will fix this problem in all the edge-cases, but it does the job for me 😉 

Nice plugin! 